### PR TITLE
Fix spacing around unordered list elements

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -75,7 +75,8 @@ ul {
 }
 
 li {
-  margin-bottom: .5em;
+  margin-bottom: 0.5em;
+  margin-top: 0.5em;
 }
 
 hr {


### PR DESCRIPTION
Addresses #4.  Adding margin to the top adds space between nested list elements and their parent.