### PR TITLE
Eliminate the need for nbsp's in .md files

### DIFF
--- a/_layouts/basic.html
+++ b/_layouts/basic.html
@@ -5,7 +5,7 @@
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>{{ page.title }}</title>
+    <title>{% if page.title%}{{ " — " | prepend: page.title | append: site.name }}{% else %}{{ site.name }}{% endif %}</title>
     <meta name="keywords" content="Tectonic, Tectonic Typesetting, TeX, LaTeX">
     <meta name="description" content="A modernized, complete, standalone TeX/LaTeX engine.">
 

--- a/_layouts/basic.html
+++ b/_layouts/basic.html
@@ -26,6 +26,7 @@
 	  <h2><a href="/en-US/develop.html">For Developers</a></h2>
 	</li>
       </ul>
+      <h1 class="title">{{ page.title }}</h1>
     </header>
 
     {{ content }}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,6 +2,11 @@
 layout: basic
 ---
 
-<div class="content">
-  {{ content }}
-</div>
+<body>
+
+    <div class="content">
+        <h1 class="title">{{ page.title }}</h1>
+      {{ content }}
+    </div>
+
+</body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,11 +2,6 @@
 layout: basic
 ---
 
-<body>
-
-    <div class="content">
-        <h1 class="title">{{ page.title }}</h1>
-      {{ content }}
-    </div>
-
-</body>
+<div class="content">
+  {{ content }}
+</div>

--- a/css/style.css
+++ b/css/style.css
@@ -106,6 +106,16 @@ hr {
 
 /* "basic.html" layout stuff */
 
+.content h1.title {
+  font-size: 2.5em;
+  line-height: 1.5em;
+  margin-top: 0em;
+  margin-bottom: 1rem;
+  font-weight: 400;
+  position: relative;
+}
+
+
 .content {
   border-top: 2px solid #dedede;
   margin-top: 2em;
@@ -124,7 +134,7 @@ hr {
 .content h1 {
   font-size: 2.5em;
   line-height: 1.5em;
-  margin-top: 0;
+  margin-top: 2.85em;
   margin-bottom: 1rem;
   font-weight: 400;
   position: relative;

--- a/css/style.css
+++ b/css/style.css
@@ -106,10 +106,12 @@ hr {
 
 /* "basic.html" layout stuff */
 
-.content h1.title {
+h1.title {
   font-size: 2.5em;
   line-height: 1.5em;
-  margin-top: 0em;
+  border-top: 2px solid #dedede;
+  margin-top: 0.8em;
+  padding-top: 0.8em;
   margin-bottom: 1rem;
   font-weight: 400;
   position: relative;
@@ -117,10 +119,7 @@ hr {
 
 
 .content {
-  border-top: 2px solid #dedede;
-  margin-top: 2em;
   margin-bottom: 8em;
-  padding-top: 2em;
 }
 
 .content p,

--- a/en-US/develop.md
+++ b/en-US/develop.md
@@ -1,9 +1,7 @@
 ---
 layout: default
-title: For Developers — The Tectonic Project
+title: Developing Tectonic
 ---
-
-# Developing Tectonic
 
 Due to its historical baggage, Tectonic is written in a combination of C, C++,
 and [Rust](https://www.rust-lang.org/). The aim is to eventually transition it

--- a/en-US/install.md
+++ b/en-US/install.md
@@ -1,9 +1,7 @@
 ---
 layout: default
-title: Installation — The Tectonic Project
+title: Installing Tectonic
 ---
-
-# Installing Tectonic
 
 There are several options for installing Tectonic. The best choice depends on
 your computing environment.
@@ -25,9 +23,6 @@ installation methods are welcomed! We are happy to provide other installers
 but are not sure what the community needs. Please express your preferences <a
 href="https://github.com/tectonic-typesetting/tectonic-typesetting.github.io/issues/1">on
 GitHub</a>.</p>
-
-<p>&nbsp;<br>&nbsp;<br>&nbsp;<br>&nbsp;</p> <!-- sigh -->
-
 
 # Pre-built binary packages
 
@@ -57,9 +52,6 @@ by running `makepkg` in the package directory
 cd tectonic
 makepkg -si
 ```
-
-<p>&nbsp;<br>&nbsp;<br>&nbsp;<br>&nbsp;</p> <!-- sigh -->
-
 
 # The `cargo install` method
 
@@ -145,9 +137,6 @@ It *may* be possible to install Tectonic using the Ubuntu Linux instructions
 above if you have enabled the *Windows Subsystem for Linux*. Please
 [file a GitHub issue on this website](https://github.com/tectonic-typesetting/tectonic-typesetting.github.io/issues)
 with instructions or a correction if you attempt this!
-
-<p>&nbsp;<br>&nbsp;<br>&nbsp;<br>&nbsp;</p> <!-- sigh -->
-
 
 # The Anaconda method
 


### PR DESCRIPTION
This adds a space to h1's to take the place of the nbsp's.  This would normally affect the title, which is also in an h1, but the title is now derived from the title in the YAML header of the .md file and is in the header of the page instead of the body.  The title of the web page (in the head) is now "<page title> --- The Tectonic Typesetting System" if page title is defined, or just "The Tectonic Typesetting System" otherwise.  That is the only change to the look of the site, the layout is completely unchanged (though I only tested it in firefox).