### PR TITLE
install.md: adding zlib to macOS dependencies

### DIFF
--- a/en-US/install.md
+++ b/en-US/install.md
@@ -120,7 +120,7 @@ The recommended way to install the required dependencies is with
 libraries; please note that an unusual argument is needed for `harfbuzz`:
 
 ```
-brew install freetype graphite2 icu4c libpng openssl pkg-config
+brew install freetype graphite2 icu4c libpng openssl pkg-config zlib
 brew install harfbuzz --with-graphite2
 ```
 


### PR DESCRIPTION
I had to install zlib too, otherwise I'd get a `z_const not defined` error along a million warnings.