### PR TITLE
Add `libssl-dev` to Ubuntu packages

### DIFF
--- a/en-US/install.md
+++ b/en-US/install.md
@@ -103,7 +103,7 @@ steps are broken out by operating system below.
 Ensure that the requisite packages are installed with the following command:
 
 ```
-sudo apt-get install libfontconfig1-dev libgraphite2-dev libharfbuzz-dev libicu-dev zlib1g-dev
+sudo apt-get install libfontconfig1-dev libgraphite2-dev libharfbuzz-dev libicu-dev libssl-dev zlib1g-dev
 ```
 
 Once that is done, the following should be sufficient to download and install


### PR DESCRIPTION
In a fresh Vagrant Ubuntu 18 system, following the instructions failed:

<pre>error: failed to run custom build command for `openssl-sys v0.9.35`
process didn't exit successfully: `/tmp/cargo-installf4xTMQ/release/build/openssl-sys-ea4f7929f8771d41/build-script-main` (exit code: 101)
--- stdout
cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_LIB_DIR
cargo:rerun-if-env-changed=OPENSSL_LIB_DIR
cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_INCLUDE_DIR
cargo:rerun-if-env-changed=OPENSSL_INCLUDE_DIR
cargo:rerun-if-env-changed=X86_64_UNKNOWN_LINUX_GNU_OPENSSL_DIR
cargo:rerun-if-env-changed=OPENSSL_DIR
run pkg_config fail: "`\"pkg-config\" \"--libs\" \"--cflags\" \"openssl\"` did not exit successfully: exit code: 1\n--- stderr\nPackage openssl was not found in the pkg-config search path.\nPerhaps you should add the directory containing `openssl.pc\'\nto the PKG_CONFIG_PATH environment variable\nNo package \'openssl\' found\n"</pre>

I had to install `libssl-dev` to get it working.