### PR TITLE
en-US/index.html: have installation button stay here, rather than going to the book

### DIFF
--- a/en-US/index.html
+++ b/en-US/index.html
@@ -13,7 +13,7 @@ title: The Tectonic Typesetting System
     </p>
   </div>
   <div class="col-md-4">
-    <a class="release-button" href="/book/latest/installation/">
+    <a class="release-button" href="/install.html">
       <div class="release-version">Install Tectonic <span>{{ site.latest }}</span></div>
     </a>
     <div class="release-date">{{ site.latest_date | date: "%B %-d, %Y" }} •


### PR DESCRIPTION
Now that we have nice fancy curl-sh installers, it's worthwhile to emphasize them.