### PR TITLE
support/drop-installer.sh: fixed breaking _arch variable check before assignment

### DIFF
--- a/support/drop-installer.sh
+++ b/support/drop-installer.sh
@@ -32,6 +32,10 @@ main() {
     need_cmd uname
     need_cmd rm
 
+    get_architecture || return 1
+    local _arch="$RETVAL"
+    assert_nz "$_arch" "arch"
+
     local _ext=".tar.gz"
     case "$_arch" in
         *windows*)
@@ -42,10 +46,6 @@ main() {
             need_cmd tar
             ;;
     esac
-
-    get_architecture || return 1
-    local _arch="$RETVAL"
-    assert_nz "$_arch" "arch"
     say "downloading version ${_version} for architecture ${_arch}"
 
     local _url="https://github.com/tectonic-typesetting/tectonic/releases/download/"


### PR DESCRIPTION
It appears that while dealing with #50 I actually committed a copy of the script I was using for testing and as such pushed broken code on Windows (I actually tested with the correct code but committed some other earlier version). I am mortified and take full responsibility for this mistake. This PR is meant to fix the change by moving the variable check to the correct place. I also tested this code on a Windows machine (in Git Bash) again and everything is working correctly.